### PR TITLE
US48-Feat/ Adding an icon for the purchasing team

### DIFF
--- a/client/src/components/TopBar/TopBar.tsx
+++ b/client/src/components/TopBar/TopBar.tsx
@@ -1,7 +1,7 @@
 import AppBar from "@mui/material/AppBar";
 import Typography from "@mui/material/Typography";
 import SupervisorAccountIcon from "@mui/icons-material/SupervisorAccount";
-import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import ConstructionOutlinedIcon from "@mui/icons-material/ConstructionOutlined";
 import { useUser } from "../../contexts/UserContext";
@@ -12,7 +12,9 @@ export default function TopBar() {
   const teamIcon = (role: string) => {
     switch (role) {
       case "1": // Achat
-        return <ShoppingCartIcon fontSize="large" sx={{ color: "#383E49" }} />;
+        return (
+          <HandshakeOutlinedIcon fontSize="large" sx={{ color: "#383E49" }} />
+        );
       case "2": // Appro
         return <AssignmentIcon fontSize="large" sx={{ color: "#383E49" }} />;
       case "3": // Atelier


### PR DESCRIPTION
**US48 - Feat: Adding an Icon for the Purchasing Team**

- Ajout d'une icône spécifique pour représenter l'équipe achat, intégrée dynamiquement en fonction du contexte utilisateur.

![Capture d’écran 2024-12-04 172923](https://github.com/user-attachments/assets/c5deb7fc-3ecf-44b2-be29-25ca45bf4955)
