### PR TITLE
US32-Feat/ Addition of an icon representing the provisionemnet service

### DIFF
--- a/client/src/components/TopBar/TopBar.tsx
+++ b/client/src/components/TopBar/TopBar.tsx
@@ -2,7 +2,7 @@ import AppBar from "@mui/material/AppBar";
 import Typography from "@mui/material/Typography";
 import SupervisorAccountIcon from "@mui/icons-material/SupervisorAccount";
 import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
-import AssignmentIcon from "@mui/icons-material/Assignment";
+import LocalShippingOutlinedIcon from "@mui/icons-material/LocalShippingOutlined";
 import ConstructionOutlinedIcon from "@mui/icons-material/ConstructionOutlined";
 import { useUser } from "../../contexts/UserContext";
 
@@ -16,7 +16,12 @@ export default function TopBar() {
           <HandshakeOutlinedIcon fontSize="large" sx={{ color: "#383E49" }} />
         );
       case "2": // Appro
-        return <AssignmentIcon fontSize="large" sx={{ color: "#383E49" }} />;
+        return (
+          <LocalShippingOutlinedIcon
+            fontSize="large"
+            sx={{ color: "#383E49" }}
+          />
+        );
       case "3": // Atelier
         return (
           <ConstructionOutlinedIcon


### PR DESCRIPTION
**US32 - Feat : Ajout d'une icône pour le service approvisionnement**

**Description**
- Ajout d'une icône dans la topbar, visible uniquement si l'ID de l'utilisateur correspond au service approvisionnement.

**Détails**
- Mise à jour du composant topbar pour inclure un rendu conditionnel de l'icône du service approvisionnement.

![Capture d’écran 2024-12-05 092931](https://github.com/user-attachments/assets/1256d618-417f-4c1f-b167-052e681d9d51)
