### PR TITLE
Fix/resumption of css for the dashboard list component

### DIFF
--- a/client/src/components/DashboardList/DashboardList.tsx
+++ b/client/src/components/DashboardList/DashboardList.tsx
@@ -5,20 +5,17 @@ import useScreenSize from "../../hook/useScreenSize";
 interface DashboardListProps<T> {
   columns: GridColDef[];
   data: Array<T>;
+  withSummary?: boolean;
 }
 
 export default function DashboardList<T>({
   columns,
   data,
+  withSummary = false,
 }: DashboardListProps<T>) {
-  const { isSmallScreen, isMediumScreen } = useScreenSize();
-
-  const rowPerPage = isSmallScreen ? 7 : isMediumScreen ? 12 : 26;
-  const dataGridHeight = isSmallScreen
-    ? "473px"
-    : isMediumScreen
-      ? "734px"
-      : "1461px";
+  const { dataGridHeight, rowPerPage } = useScreenSize({
+    withSummary,
+  });
 
   return (
     <Box component="main">

--- a/client/src/hook/useScreenSize.ts
+++ b/client/src/hook/useScreenSize.ts
@@ -1,11 +1,20 @@
 import { useMediaQuery } from "@mui/material";
 
-const useScreenSize = () => {
+const useScreenSize = (options?: { withSummary?: boolean }) => {
   const isSmallScreen = useMediaQuery("(max-width:1920px)");
   const isMediumScreen = useMediaQuery("(max-width:2560px)");
   const isLargeScreen = useMediaQuery("(min-width:2561px)");
 
-  return { isSmallScreen, isMediumScreen, isLargeScreen };
+  const baseHeight = isSmallScreen ? 473 : isMediumScreen ? 734 : 1461;
+
+  const adjustedHeight = options?.withSummary ? baseHeight - 100 : baseHeight;
+
+  return {
+    isSmallScreen,
+    isMediumScreen,
+    isLargeScreen,
+    dataGridHeight: `${adjustedHeight}px`,
+  };
 };
 
 export default useScreenSize;

--- a/client/src/hook/useScreenSize.ts
+++ b/client/src/hook/useScreenSize.ts
@@ -6,14 +6,27 @@ const useScreenSize = (options?: { withSummary?: boolean }) => {
   const isLargeScreen = useMediaQuery("(min-width:2561px)");
 
   const baseHeight = isSmallScreen ? 473 : isMediumScreen ? 734 : 1461;
+  const baseHeightWithoutSummary = isSmallScreen
+    ? 629
+    : isMediumScreen
+      ? 1149
+      : 1877;
 
-  const adjustedHeight = options?.withSummary ? baseHeight - 100 : baseHeight;
+  const adjustedHeight = options?.withSummary
+    ? baseHeight
+    : baseHeightWithoutSummary;
+
+  const rowWithSummary = isSmallScreen ? 7 : isMediumScreen ? 12 : 26;
+  const rowWithoutSummary = isSmallScreen ? 10 : isMediumScreen ? 20 : 35;
+
+  const rowPerPage = options?.withSummary ? rowWithSummary : rowWithoutSummary;
 
   return {
     isSmallScreen,
     isMediumScreen,
     isLargeScreen,
     dataGridHeight: `${adjustedHeight}px`,
+    rowPerPage,
   };
 };
 

--- a/client/src/pages/AdminHomePage/AdminHomePage.tsx
+++ b/client/src/pages/AdminHomePage/AdminHomePage.tsx
@@ -178,7 +178,11 @@ export default function AdminHomePage() {
             </Button>
           </Box>
         </Box>
-        <DashboardList columns={columns} data={dataGridUser} />
+        <DashboardList
+          columns={columns}
+          data={dataGridUser}
+          withSummary={false}
+        />
 
         {/* Modal for Creating a User */}
         <ModalForm

--- a/client/src/pages/InventoryPage/InventoryPage.tsx
+++ b/client/src/pages/InventoryPage/InventoryPage.tsx
@@ -124,7 +124,11 @@ export default function InventoryPage() {
               </Button>
             </Box>
           </Box>
-          <DashboardList columns={columns} data={dataGridProduct} />
+          <DashboardList
+            columns={columns}
+            data={dataGridProduct}
+            withSummary={true}
+          />
         </Box>
       </Box>
     );


### PR DESCRIPTION
**Problème résolu :**

Cette PR corrige la gestion de la hauteur dynamique du composant DashboardList en fonction de la présence ou non d'un composant comme DashboardSummary. Elle adresse les problèmes suivants :

- La hauteur du tableau ne s'ajustait pas correctement en l'absence d'un élément parent influençant le layout.
- Une logique incohérente pour le nombre de lignes affichées par page (pagination).

**Modifications principales :**
- Hook useScreenSize :
-- Ajout d'une option withSummary pour ajuster dynamiquement la hauteur (dataGridHeight) en fonction de la présence d'un composant comme DashboardSummary.
-- Centralisation de la logique pour calculer rowPerPage en fonction de la taille de l'écran et de la présence du résumé.

- Composant DashboardList :
-- Intégration de la prop withSummary pour transmettre l'information au hook useScreenSize.
-- Ajustement de la pagination (rowPerPage) en fonction de la hauteur calculée dynamiquement.

- Adaptations dans les pages :
-- Mise à jour des pages InventoryPage et AdminHomePage pour passer la prop withSummary lors de l'utilisation du composant DashboardList.

![Capture d’écran 2024-12-19 163010](https://github.com/user-attachments/assets/7be74053-3021-4ffb-aceb-153c88f2f739)